### PR TITLE
Fix sample app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM maven:3.5.4-jdk-8-alpine AS builder
 COPY pom.xml .
 COPY src src/
-COPY resources resources/
 RUN mvn install -DskipTests
 
 FROM open-liberty as server-setup
@@ -17,4 +16,6 @@ RUN apt-get update \
 FROM open-liberty
 LABEL maintainer="Graham Charters" vendor="IBM" github="https://github.com/WASdev/ci.maven"
 COPY --chown=1001:0 --from=server-setup /config/ /config/
+# user.dir environment variable is /opt/ol/wlp/output/defaultServer/resources/
+COPY resources /opt/ol/wlp/output/defaultServer/resources/
 EXPOSE 9080 9443

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
     <package.file>${project.build.directory}/${app.name}.zip</package.file>
     <packaging.type>usr</packaging.type>
     <skipTests>false</skipTests>
-    <codewind.type>generic-docker</codewind.type>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <package.file>${project.build.directory}/${app.name}.zip</package.file>
     <packaging.type>usr</packaging.type>
     <skipTests>false</skipTests>
+    <codewind.type>generic-docker</codewind.type>
   </properties>
 
   <dependencies>

--- a/src/main/java/io/openliberty/sample/config/CustomConfigSource.java
+++ b/src/main/java/io/openliberty/sample/config/CustomConfigSource.java
@@ -25,7 +25,7 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 public class CustomConfigSource implements ConfigSource {
 
   String fileLocation = System.getProperty("user.dir").split("target")[0]
-      + "resources/CustomConfigSource.json";
+      + "/resources/CustomConfigSource.json";
 
   @Override
   public int getOrdinal() {


### PR DESCRIPTION
Fixes the resource errors when the server is started within the container:
```
[err] java.io.FileNotFoundException: /opt/ol/wlp/output/defaultServer/resources/CustomConfigSource.json (No such file or directory)
[err] 	at java.io.FileInputStream.open(FileInputStream.java:212)
[err] 	at java.io.FileInputStream.<init>(FileInputStream.java:152)
[err] 	at java.io.FileInputStream.<init>(FileInputStream.java:104)
[err] 	at java.io.FileReader.<init>(FileReader.java:69)
[err] 	at io.openliberty.sample.config.CustomConfigSource.readFile(CustomConfigSource.java:86)
[err] 	at io.openliberty.sample.config.CustomConfigSource.getProperties(CustomConfigSource.java:52)
[err] 	at io.openliberty.sample.config.CustomConfigSource.getOrdinal(CustomConfigSource.java:32)
[err] 	at com.ibm.ws.microprofile.config.impl.ConfigSourceComparator.compare(ConfigSourceComparator.java:38)
[err] 	at [internal classes]
[err] 	at java.util.TreeMap.put(TreeMap.java:563)
[err] 	at java.util.TreeSet.add(TreeSet.java:266)
[err] 	at java.util.AbstractCollection.addAll(AbstractCollection.java:355)
[err] 	at java.util.TreeSet.addAll(TreeSet.java:323)
[err] 	at com.ibm.ws.microprofile.config.impl.SortedSources.addAll(SortedSources.java:50)
[err] 	at [internal classes]
[err] 	at org.eclipse.microprofile.config.ConfigProvider.getConfig(ConfigProvider.java:107)
[err] 	at com.ibm.ws.microprofile.openapi.ConfigProcessor.<init>(ConfigProcessor.java:64)
[err] 	at [internal classes]
[err] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
[err] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[err] 	at java.lang.Thread.run(Thread.java:818)
[AUDIT   ] CWWKT0016I: Web application available (default_host): http://ca526107d40b:9080/openapi/
[AUDIT   ] CWPKI0803A: SSL certificate created in 5.714 seconds. SSL key file: /opt/ol/wlp/output/defaultServer/resources/security/key.p12
[err] java.io.FileNotFoundException: /opt/ol/wlp/output/defaultServer/resources/CustomConfigSource.json (No such file or directory)
[err] 	at java.io.FileInputStream.open(FileInputStream.java:212)
[err] 	at java.io.FileInputStream.<init>(FileInputStream.java:152)
[err] 	at java.io.FileInputStream.<init>(FileInputStream.java:104)
[err] 	at java.io.FileReader.<init>(FileReader.java:69)
[err] 	at io.openliberty.sample.config.CustomConfigSource.readFile(CustomConfigSource.java:86)
[err] 	at io.openliberty.sample.config.CustomConfigSource.getProperties(CustomConfigSource.java:52)
[err] 	at io.openliberty.sample.config.CustomConfigSource.getOrdinal(CustomConfigSource.java:32)
[err] 	at com.ibm.ws.microprofile.config.impl.ConfigSourceComparator.compare(ConfigSourceComparator.java:38)
[err] 	at [internal classes]
[err] 	at java.util.TreeMap.put(TreeMap.java:563)
[err] 	at java.util.TreeSet.add(TreeSet.java:266)
[err] 	at java.util.AbstractCollection.addAll(AbstractCollection.java:355)
[err] 	at java.util.TreeSet.addAll(TreeSet.java:323)
[err] 	at com.ibm.ws.microprofile.config.impl.SortedSources.addAll(SortedSources.java:50)
[err] 	at [internal classes]
[err] 	at org.eclipse.microprofile.config.ConfigProvider.getConfig(ConfigProvider.java:93)
[err] 	at com.ibm.ws.microprofile.faulttolerance.cdi.FaultToleranceCDIExtension.afterTypeDiscovery(FaultToleranceCDIExtension.java:221)
[err] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[err] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:90)
[err] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55)
[err] 	at java.lang.reflect.Method.invoke(Method.java:508)
[err] 	at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:95)
[err] 	at [internal classes]
[err] 	at javax.enterprise.inject.spi.ObserverMethod.notify(ObserverMethod.java:124)
[err] 	at org.jboss.weld.util.Observers.notify(Observers.java:166)
[err] 	at [internal classes]
[err] 	at java.security.AccessController.doPrivileged(AccessController.java:647)
[err] 	at com.ibm.ws.cdi.impl.CDIContainerImpl.startInitialization(CDIContainerImpl.java:141)
[err] 	at [internal classes]
[err] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
[err] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[err] 	at java.lang.Thread.run(Thread.java:818)
[ERROR   ] CWWKZ0002E: An exception occurred while starting the application io.openliberty.sample.getting.started. The exception message was: com.ibm.ws.container.service.state.StateChangeException: org.jboss.weld.exceptions.DefinitionException: Exception List with 1 exceptions:
Exception 0 :
java.lang.NumberFormatException: null
	at java.lang.Integer.parseInt(Integer.java:554)
	at java.lang.Integer.parseInt(Integer.java:627)
	at io.openliberty.sample.config.CustomConfigSource.getOrdinal(CustomConfigSource.java:32)
	at com.ibm.ws.microprofile.config.impl.ConfigSourceComparator.compare(ConfigSourceComparator.java:38)
	at com.ibm.ws.microprofile.config.impl.ConfigSourceComparator.compare(ConfigSourceComparator.java:19)
	at java.util.TreeMap.put(TreeMap.java:563)
	at java.util.TreeSet.add(TreeSet.java:266)
	at java.util.AbstractCollection.addAll(AbstractCollection.java:355)
	at java.util.TreeSet.addAll(TreeSet.java:323)
	at com.ibm.ws.microprofile.config.impl.SortedSources.addAll(SortedSources.java:50)
	at com.ibm.ws.microprofile.config13.impl.Config13BuilderImpl.getSources(Config13BuilderImpl.java:61)
	at com.ibm.ws.microprofile.config.impl.AbstractConfigBuilder.build(AbstractConfigBuilder.java:143)
	at com.ibm.ws.microprofile.config.impl.AbstractProviderResolver.getConfig(AbstractProviderResolver.java:257)
	at com.ibm.ws.microprofile.config.impl.AbstractProviderResolver.getConfig(AbstractProviderResolver.java:225)
	at org.eclipse.microprofile.config.ConfigProvider.getConfig(ConfigProvider.java:93)
	at com.ibm.ws.microprofile.faulttolerance.cdi.FaultToleranceCDIExtension.afterTypeDiscovery(FaultToleranceCDIExtension.java:221)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:90)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55)
	at java.lang.reflect.Method.invoke(Method.java:508)
	at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:95)
	at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:85)
	at org.jboss.weld.injection.MethodInvocationStrategy$SimpleMethodInvocationStrategy.invoke(MethodInvocationStrategy.java:168)
	at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:330)
	at org.jboss.weld.event.ExtensionObserverMethodImpl.sendEvent(ExtensionObserverMethodImpl.java:123)
	at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:308)
	at org.jboss.weld.event.ObserverMethodImpl.notify(ObserverMethodImpl.java:286)
	at javax.enterprise.inject.spi.ObserverMethod.notify(ObserverMethod.java:124)
	at org.jboss.weld.util.Observers.notify(Observers.java:166)
	at org.jboss.weld.event.ObserverNotifier.notifySyncObservers(ObserverNotifier.java:285)
	at org.jboss.weld.event.ObserverNotifier.notify(ObserverNotifier.java:273)
	at org.jboss.weld.event.ObserverNotifier.fireEvent(ObserverNotifier.java:177)
	at org.jboss.weld.event.ObserverNotifier.fireEvent(ObserverNotifier.java:171)
	at org.jboss.weld.bootstrap.events.AbstractContainerEvent.fire(AbstractContainerEvent.java:53)
	at org.jboss.weld.bootstrap.events.AbstractDefinitionContainerEvent.fire(AbstractDefinitionContainerEvent.java:44)
	at org.jboss.weld.bootstrap.events.AfterTypeDiscoveryImpl.fire(AfterTypeDiscoveryImpl.java:45)
	at org.jboss.weld.bootstrap.WeldStartup.startInitialization(WeldStartup.java:425)
	at org.jboss.weld.bootstrap.WeldBootstrap.startInitialization(WeldBootstrap.java:79)
	at com.ibm.ws.cdi.impl.CDIContainerImpl$2.run(CDIContainerImpl.java:144)
	at com.ibm.ws.cdi.impl.CDIContainerImpl$2.run(CDIContainerImpl.java:141)
	at java.security.AccessController.doPrivileged(AccessController.java:647)
	at com.ibm.ws.cdi.impl.CDIContainerImpl.startInitialization(CDIContainerImpl.java:141)
	at com.ibm.ws.cdi.liberty.CDIRuntimeImpl.applicationStarting(CDIRuntimeImpl.java:443)
	at com.ibm.ws.container.service.state.internal.ApplicationStateManager.fireStarting(ApplicationStateManager.java:51)
	at com.ibm.ws.container.service.state.internal.StateChangeServiceImpl.fireApplicationStarting(StateChangeServiceImpl.java:50)
	at com.ibm.ws.app.manager.module.internal.SimpleDeployedAppInfoBase.preDeployApp(SimpleDeployedAppInfoBase.java:550)
	at com.ibm.ws.app.manager.module.internal.SimpleDeployedAppInfoBase.installApp(SimpleDeployedAppInfoBase.java:511)
	at com.ibm.ws.app.manager.module.internal.DeployedAppInfoBase.deployApp(DeployedAppInfoBase.java:347)
	at com.ibm.ws.app.manager.war.internal.WARApplicationHandlerImpl.install(WARApplicationHandlerImpl.java:65)
	at com.ibm.ws.app.manager.internal.statemachine.StartAction.execute(StartAction.java:140)
	at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.enterState(ApplicationStateMachineImpl.java:1266)
	at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.run(ApplicationStateMachineImpl.java:881)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:239)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.lang.Thread.run(Thread.java:818)

[AUDIT   ] CWWKF0012I: The server installed the following features: [appSecurity-2.0, cdi-2.0, concurrent-1.0, distributedMap-1.0, jaxrs-2.1, jaxrsClient-2.1, jndi-1.0, json-1.0, jsonb-1.0, jsonp-1.1, jwt-1.0, microProfile-2.0, mpConfig-1.3, mpFaultTolerance-1.1, mpHealth-1.0, mpJwt-1.1, mpMetrics-1.1, mpOpenAPI-1.0, mpOpenTracing-1.1, mpRestClient-1.1, opentracing-1.1, servlet-4.0, ssl-1.0].
[AUDIT   ] CWWKF0011I: The defaultServer server is ready to run a smarter planet. The defaultServer server started in 18.815 seconds.
```


Here is what I was seeing before:
![image](https://user-images.githubusercontent.com/20015929/63555997-09244a80-c511-11e9-8fb8-920a2147d06c.png)


This is what I see with the changes:
![image](https://user-images.githubusercontent.com/20015929/63555857-931fe380-c510-11e9-8036-cd4b3874f4b3.png)

And if you scroll down a bit more and expand the Config section you should see the following if the sample is working correctly:
![image](https://user-images.githubusercontent.com/20015929/63555897-bcd90a80-c510-11e9-9a9c-48206db1fd07.png)