### PR TITLE
Add helm chart to the Open Liberty template

### DIFF
--- a/chart/openlibertytemplate/Chart.yaml
+++ b/chart/openlibertytemplate/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Open Liberty on Kubernetes
+name: openlibertytemplate
+version: 1.0.0

--- a/chart/openlibertytemplate/templates/deployment.yaml
+++ b/chart/openlibertytemplate/templates/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ .Chart.Name }}-deployment"
+  labels:
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}'
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: "{{ .Chart.Name }}-selector"
+        version: "current"
+    spec:
+      containers:
+      - name: "{{ .Chart.Name }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.servicePort }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.service.servicePort }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.service.servicePort }}
+        resources:
+        env:
+        - name: PORT
+          value: "{{ .Values.service.servicePort }}"
+

--- a/chart/openlibertytemplate/templates/service.yaml
+++ b/chart/openlibertytemplate/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{  .Chart.Name }}-service"
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.service.servicePort }}
+  selector:
+    app: "{{ .Chart.Name }}-selector"

--- a/chart/openlibertytemplate/values.yaml
+++ b/chart/openlibertytemplate/values.yaml
@@ -1,0 +1,22 @@
+# Default values for microclimateGoExample.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: sample
+  tag: v0.1.0
+  pullPolicy: Always
+
+service:
+  name: Node
+  type: NodePort
+  servicePort: 9080
+
+resources:
+  cpu: 100m
+  memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

Adds a Helm chart to the Open Liberty template so that the template can be deployed on Kubernetes / OpenShift.